### PR TITLE
New Pwm

### DIFF
--- a/pingo/board.py
+++ b/pingo/board.py
@@ -154,7 +154,6 @@ class AnalogInputCapable(object):
         the procedure to read pin analog signal changes from board to board.
         """
 
-    # FIX: Should we drop it?
     @abstractmethod
     def _set_analog_mode(self, pin, mode):
         """Abstract method to be implemented by each ``Board`` subclass.

--- a/pingo/board.py
+++ b/pingo/board.py
@@ -202,6 +202,15 @@ class PwmOutputCapable(object):
             return pin._duty_cycle
         return 0.0
 
+    def _get_pwm_frequency(self, pin):
+        """
+        This method should be overwritten if the ``Board`` subclass
+        has this feature.
+        """
+        if hasattr(pin, '_frequency'):
+            return pin._frequency
+        return 0.0
+
 
 class Pin(object):
     """Abstract class defining common interface for all pins."""
@@ -314,6 +323,9 @@ class PwmPin(DigitalPin):
         self._frequency = frequency
         self._duty_cycle = None
 
+    # TUDO:
+    # Write a decorator to test mode == 'MODE'
+
     @property
     def value(self):
         if self.mode != PWM:
@@ -328,6 +340,21 @@ class PwmPin(DigitalPin):
             raise ArgumentOutOfRange()
         self.board._set_pwm_duty_cycle(self, value)
         self._duty_cycle = value
+
+    @property
+    def frequency(self):
+        if self.mode != PWM:
+            raise WrongPinMode()
+        return self.board._get_pwm_frequency(self)
+
+    @frequency.setter
+    def frequency(self, new_frequency):
+        if self.mode != PWM:
+            raise WrongPinMode()
+        if new_frequency <= 0.0:
+            raise ArgumentOutOfRange()
+        self.board._set_pwm_frequency(self, new_frequency)
+        self._frequency = new_frequency
 
 
 class AnalogPin(Pin):

--- a/pingo/board.py
+++ b/pingo/board.py
@@ -193,6 +193,15 @@ class PwmOutputCapable(object):
         the procedure to set PWM's duty cycle changes from board to board.
         """
 
+    def _get_pwm_duty_cycle(self, pin):
+        """
+        This method should be overwritten if the ``Board`` subclass
+        has this feature.
+        """
+        if hasattr(pin, '_duty_cycle'):
+            return pin._duty_cycle
+        return 0.0
+
 
 class Pin(object):
     """Abstract class defining common interface for all pins."""
@@ -309,9 +318,7 @@ class PwmPin(DigitalPin):
     def value(self):
         if self.mode != PWM:
             raise WrongPinMode()
-        if hasattr(pin, '_duty_cycle'):
-            return self._duty_cycle
-        return None
+        return self.board._get_pwm_duty_cycle(self)
 
     @value.setter
     def value(self, value):

--- a/pingo/board.py
+++ b/pingo/board.py
@@ -178,11 +178,11 @@ class PwmOutputCapable(object):
         """Abstract method to be implemented by each ``Board`` subclass."""
 
     @abstractmethod
-    def _get_pwm_duty_cycle(self, pin):
+    def _set_pwm_frequency(self, pin, value):
         """Abstract method to be implemented by each ``Board`` subclass.
 
-        The ``«PwmPin».value(…)`` method calls this method because
-        the procedure to read the PWM signal changes from board to board.
+        The ``«PwmPin».frequency(…)`` method calls this method because
+        the procedure to set the PWM's frequency changes from board to board.
         """
 
     @abstractmethod
@@ -190,7 +190,7 @@ class PwmOutputCapable(object):
         """Abstract method to be implemented by each ``Board`` subclass.
 
         The ``«PwmPin».value(…)`` method calls this method because
-        the procedure to write a PWM signal changes from board to board.
+        the procedure to set PWM's duty cycle changes from board to board.
         """
 
 
@@ -300,11 +300,18 @@ class PwmPin(DigitalPin):
 
     suported_modes = [IN, OUT, PWM]
 
+    def __init__(self, board, location, gpio_id=None, frequency=None):
+        DigitalPin.__init__(self, board, location, gpio_id)
+        self._frequency = frequency
+        self._duty_cycle = None
+
     @property
     def value(self):
         if self.mode != PWM:
             raise WrongPinMode()
-        return self.board._get_pwm_duty_cycle(self)
+        if hasattr(pin, '_duty_cycle'):
+            return self._duty_cycle
+        return None
 
     @value.setter
     def value(self, value):
@@ -313,6 +320,7 @@ class PwmPin(DigitalPin):
         if not 0.0 <= value <= 100.0:
             raise ArgumentOutOfRange()
         self.board._set_pwm_duty_cycle(self, value)
+        self._duty_cycle = value
 
 
 class AnalogPin(Pin):

--- a/pingo/galileo/galileo.py
+++ b/pingo/galileo/galileo.py
@@ -67,12 +67,8 @@ class Galileo2(pingo.Board, pingo.AnalogInputCapable, pingo.PwmOutputCapable):
     def _get_pin_value(self, pin):
         return self.mraa_analogs[pin.location].read()
 
-    def _get_pwm_duty_cycle(self, pin):
-        if hasattr(pin, '_duty_cycle'):
-            return pin._duty_cycle
-        else:
-            return 0.0
-
     def _set_pwm_duty_cycle(self, pin, value):
         self.mraa_pwms[pin.location].write(value)
-        pin._duty_cycle = value
+
+    def _set_pwm_frequency(self, pin, value):
+        raise NotImplementedError

--- a/pingo/ghost/ghost.py
+++ b/pingo/ghost/ghost.py
@@ -83,3 +83,6 @@ class GhostBoard(
 
     def _set_pwm_duty_cycle(self, pin, value):
         self._pin_states[pin.location] = value
+
+    def _set_pwm_frequency(self, pin, value):
+        raise NotImplementedError

--- a/pingo/ghost/ghost.py
+++ b/pingo/ghost/ghost.py
@@ -85,4 +85,4 @@ class GhostBoard(
         self._pin_states[pin.location] = value
 
     def _set_pwm_frequency(self, pin, value):
-        raise NotImplementedError
+        pass

--- a/pingo/rpi/rpi.py
+++ b/pingo/rpi/rpi.py
@@ -2,39 +2,6 @@ import pingo
 
 GPIO = None
 
-try:
-    import RPi.GPIO as GPIO
-except ImportError:
-    pass
-else:
-    class PwmWrapper(GPIO.PWM):
-        def __init__(self, channel, frequency=60.):
-            """
-                PwmWrapper recives a integer and a float.
-                - channel as GPIO number
-                - PWM's frequency in Hz
-            """
-            self.is_running = False
-            self.duty_cycle = 100.
-            super(PwmWrapper, self).__init__(channel, frequency)
-
-        def start(self, duty_cycle):
-            self.is_running = True
-            self.duty_cycle = duty_cycle
-            return super(PwmWrapper, self).start(duty_cycle)
-
-        def stop(self):
-            self.is_running = False
-            return super(PwmWrapper, self).stop()
-
-        def ChangeDutyCycle(self, duty_cycle):
-            self.duty_cycle = duty_cycle
-            if not self.is_running:
-                self.start(duty_cycle)
-            return super(PwmWrapper, self).ChangeDutyCycle(duty_cycle)
-
-        # TODO: ChangeFrequency
-
 
 class RaspberryPi(pingo.Board, pingo.PwmOutputCapable):
 
@@ -83,6 +50,7 @@ class RaspberryPi(pingo.Board, pingo.PwmOutputCapable):
                  for location, gpio_id in self.PWM_PIN_MAP.items()]
 
         self._add_pins(pins)
+        self.rpi_gpio = {}
 
     def cleanup(self):
         for pin in self.pins.values():
@@ -93,10 +61,9 @@ class RaspberryPi(pingo.Board, pingo.PwmOutputCapable):
     def _set_pin_mode(self, pin, mode):
         # Cleans previous PWM mode
         if pin.mode == pingo.PWM:
-            # if hasattr(pin, 'pwm_ctrl'):
-            if pin.pwm_ctrl.is_running:
-                pin.pwm_ctrl.stop()
-                del pin.pwm_ctrl
+            if int(pin.location) in self.rpi_gpio:
+                self.rpi_gpio[int(pin.location)].stop()
+                del self.rpi_gpio[int(pin.location)]
         # Sets up new modes
         if mode == pingo.IN:
             GPIO.setup(int(pin.gpio_id), GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
@@ -106,7 +73,9 @@ class RaspberryPi(pingo.Board, pingo.PwmOutputCapable):
     def _set_pwm_mode(self, pin, mode):
         if pin.mode != pingo.PWM:
             GPIO.setup(int(pin.gpio_id), GPIO.OUT)
-            pin.pwm_ctrl = PwmWrapper(int(pin.gpio_id))
+            pwm_ctrl = GPIO.PWM(int(pin.gpio_id), 60.)  # TODO set frequency
+            self.rpi_gpio[int(pin.location)] = pwm_ctrl
+            pwm_ctrl.start(0.0)  # TODO set DutyCycle
 
     def _set_pin_state(self, pin, state):
         rpi_state = GPIO.HIGH if state == pingo.HIGH else GPIO.LOW
@@ -115,11 +84,11 @@ class RaspberryPi(pingo.Board, pingo.PwmOutputCapable):
     def _get_pin_state(self, pin):
         return pingo.HIGH if GPIO.input(int(pin.gpio_id)) else pingo.LOW
 
-    def _get_pwm_duty_cycle(self, pin):
-        return pin.pwm_ctrl.duty_cycle
-
     def _set_pwm_duty_cycle(self, pin, value):
-        pin.pwm_ctrl.ChangeDutyCycle(value)
+        self.rpi_gpio[int(pin.location)].ChangeDutyCycle(value)
+
+    def _set_pwm_frequency(self, pin, value):
+        self.rpi_gpio[int(pin.location)].ChangeFrequency(value)
 
 
 class RaspberryPiBPlus(RaspberryPi):

--- a/pingo/test/level2/cases.py
+++ b/pingo/test/level2/cases.py
@@ -20,6 +20,15 @@ class PwmBasics(object):
         assert 0.49 <= _duty_cycle <= 0.51
 
 
+    def test_frequency(self):
+        pin = self.board.pins[self.pwm_pin_number]
+        pin.mode = pingo.PWM
+        pin.frequency = 440
+
+        _frequency = pin.frequency
+        assert 439 <= _frequency <= 441
+
+
 class PwmExceptions(object):
 
     def test_wrong_analog_mode(self):

--- a/pingo/test/level2/cases.py
+++ b/pingo/test/level2/cases.py
@@ -19,7 +19,6 @@ class PwmBasics(object):
 
         assert 0.49 <= _duty_cycle <= 0.51
 
-
     def test_frequency(self):
         pin = self.board.pins[self.pwm_pin_number]
         pin.mode = pingo.PWM

--- a/pingo/util.py
+++ b/pingo/util.py
@@ -79,3 +79,14 @@ class StrKeyDict(UserDict.UserDict):
                 self[key] = value
         if kwds:
             self.update(kwds)
+
+
+# Decorator
+# def mode_restricted(mode):
+#     def restriction_decorator(method):
+#         def method_wrapper(self, *args, **kwargs):
+#             if self.mode != mode:
+#                 raise WrongPinMode()
+#             return method(self, *args, **kwargs)
+#         return method_wrapper
+#     return mode_restricted


### PR DESCRIPTION
Changes discussed on the topic: PWM pins
```
1) The abstractmethod decorator from _get_pwm_duty_cycle will be dropped
So the _get_pwm_duty_cycle will have a implementation. It will hold the last set value.
If some Board can probe its hardware, then this Board should overwrite this method.

2) PwmPin will recive the "frequency||period" property;
This property can be read and write.
Each board should implement its own default values.

3) PwmOutputCapable recives a new abstractmethod _set_pwm_frequency and a _get_pwm_frequency
Each driver take care of his own _set_pwm_frequency. But _get_pwm_frequency has a default implementation (hold the last set value). If a Board has a better method, this should be overwritten.
```